### PR TITLE
use resolved project version

### DIFF
--- a/src/main/java/q3769/maven/plugins/semver/SemverMojo.java
+++ b/src/main/java/q3769/maven/plugins/semver/SemverMojo.java
@@ -110,7 +110,7 @@ public abstract class SemverMojo extends AbstractMojo {
 
   /** @return original version in pom.xml */
   protected String originalPomVersion() {
-    return project.getOriginalModel().getVersion();
+    return project.getModel().getVersion();
   }
 
   protected void logError(String message, Object... args) {


### PR DESCRIPTION
In our project, we use a property in the POM to determine the current version, e.g. "myversion". Using the current implementation of the plugin, it complains that "${myversion}" is not a semantic version. With the changes, the property gets resolved and the plugin is happy again.